### PR TITLE
fix(algorithm): harden chart generation against per-subsection failures

### DIFF
--- a/openjiuwen_deepsearch/algorithm/chart_generation/figure_placeholders.py
+++ b/openjiuwen_deepsearch/algorithm/chart_generation/figure_placeholders.py
@@ -263,6 +263,11 @@ class FigurePlaceholderGenerator:
             logger.error(f"Error processing sections_h1: {len(results)} != {len(sections)}")
         h1_tasks = []
         for result in results:
+            if not isinstance(result, list):
+                # 单个二级章节处理失败（异常或返回 None）时跳过，避免拖垮整个一级章节
+                if isinstance(result, Exception):
+                    logger.error(f"Error processing section_h2: {result}")
+                continue
             h1_tasks.extend(result)
         # 为每个一级章节下的图表生成唯一的图表id
         chart_id_in_section = 0
@@ -311,6 +316,7 @@ class FigurePlaceholderGenerator:
             logger.error(
                 f"[CHART GENERATION] Error calling LLM for section {section_title}: {e}"
             )
+            return []
 
     @staticmethod
     def _parse_llm_response(

--- a/openjiuwen_deepsearch/algorithm/source_trace/source_tracer_preprocessors.py
+++ b/openjiuwen_deepsearch/algorithm/source_trace/source_tracer_preprocessors.py
@@ -240,7 +240,7 @@ def _remove_reference_section(report_text: str) -> Tuple[str, str]:
         # 检查标题文字是否匹配参考文献模式
         if re.search(reference_pattern, title_content, re.IGNORECASE):
             # 找到这个标题之后的所有内容
-            section_pattern = rf'{re.escape(title_text)}\s*\n.*?(?=\n#{1, 6}\s.+$|$)'
+            section_pattern = rf'{re.escape(title_text)}\s*\n.*?(?=\n#{{1,6}}\s.+$|$)'
             match = re.search(section_pattern, report_text[start:], re.DOTALL)
             if match:
                 last_ref_match = (start, start + match.end())

--- a/tests/algorithm/chart_generation/test_figure_placeholders_h1_resilience.py
+++ b/tests/algorithm/chart_generation/test_figure_placeholders_h1_resilience.py
@@ -1,0 +1,55 @@
+"""Regression tests for figure placeholder H1 aggregation error handling.
+
+A single failing H2 subsection must not crash the whole H1 section:
+`_process_section_h2` returns `[]` on error, and `_process_section_h1`
+skips any non-list result (None or an Exception surfaced by
+`asyncio.gather(..., return_exceptions=True)`).
+"""
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from openjiuwen_deepsearch.algorithm.chart_generation.figure_placeholders import (
+    FigurePlaceholderGenerator,
+)
+
+pytestmark = pytest.mark.unit
+
+
+@pytest.mark.asyncio
+async def test_process_section_h2_returns_empty_list_on_llm_error():
+    """A failed LLM call yields an empty list, never None."""
+    generator = FigurePlaceholderGenerator("dummy-model")
+    section = {"title": "Section", "content": "some paragraph\nanother paragraph"}
+
+    with patch(
+        "openjiuwen_deepsearch.algorithm.chart_generation.figure_placeholders.call_model",
+        new=AsyncMock(side_effect=RuntimeError("llm down")),
+    ):
+        result = await generator._process_section_h2(section)
+
+    assert result == []
+
+
+@pytest.mark.asyncio
+async def test_process_section_h1_skips_none_and_exception_results():
+    """H1 aggregation tolerates failing subsections without raising TypeError."""
+    generator = FigurePlaceholderGenerator("dummy-model")
+    sections = [
+        {"title": "good", "content": "c1"},
+        {"title": "none-fail", "content": "c2"},
+        {"title": "exc-fail", "content": "c3"},
+    ]
+    good_task = [{"chart_desc": "x"}]
+
+    # None simulates the pre-fix silent-failure return; the Exception simulates
+    # an uncaught error surfaced by gather(return_exceptions=True).
+    with patch.object(
+        generator,
+        "_process_section_h2",
+        new=AsyncMock(side_effect=[good_task, None, RuntimeError("boom")]),
+    ):
+        result = await generator._process_section_h1(sections)
+
+    assert result == [{"chart_desc": "x", "chart_id_in_section": 1}]


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1) If this is your first time, please read our contributor guidelines: https://gitcode.com/openJiuwen/openJiuwen/blob/master/CONTRIBUTING.md

2) If you want to contribute your code but don't know who will review and merge, please add label `openJiuwen-assistant` to the pull request, we will find and do it as soon as possible.
-->

**What type of PR is this?**
<!-- 
Choose one label from `bug`, `task`, `feature` and `refactor`, and replace `<label>` below the comment block. 

If this pr is not only bugfix/task/feature and also a refactor, you can append `/kind refactor` label after `/kind bug`, `/kind task` and `/kind feature`.
-->
/kind <bugfix>

**What does this PR do / why do we need it**:

* Prevent a single failing H2 subsection from crashing an entire H1 section during chart-task generation:
  - `_process_section_h2` now returns `[]` on its exception path instead of falling off the end and returning `None`.
  - `_process_section_h1` skips any non-list `gather` result (`None`, or an `Exception` surfaced by `return_exceptions=True`) before `extend()`, avoiding a `TypeError` that turned a recoverable per-subsection error into a full-section crash.
* Also fix a latent regex bug in `_remove_reference_section`: the boundary pattern was built with an f-string, so `#{1, 6}` was interpolated as the tuple `(1, 6)` instead of the quantifier `#{1,6}`. Behavior is unchanged today (the match end is not used by the current slicing), but the regex now means what it reads; this removes a trap for future edits.
* Adds regression tests for the chart H1/H2 error handling.

**Which issue(s) this PR fixes**:

N/A (no tracked issue)

**What scenarios were tested, and what were the verification results (Function, performance, reliability, etc.)**:

* Function — New unit tests in `tests/algorithm/chart_generation/test_figure_placeholders_h1_resilience.py`:
  - `test_process_section_h2_returns_empty_list_on_llm_error`: a failing `call_model` yields `[]`, never `None`.
  - `test_process_section_h1_skips_none_and_exception_results`: with subsection results `[good_task, None, RuntimeError]`, aggregation returns only the good task (`chart_id_in_section=1`) and does not raise `TypeError`.
* Reliability — Before the fix, one failed H2 LLM call aborted the whole H1 section (and, via `gather(return_exceptions=True)`, propagated an Exception object downstream); after the fix, failed subsections are skipped and remaining charts are still generated.
* Regression / no side effects:
  - `pytest tests/algorithm/chart_generation tests/source_tracer` -> 55 passed.
  - Full run across the three touched subsystems -> 378 passed (1 pre-existing failure `test_simple_react_telemetry_uses_built_tool_map`, confirmed failing on clean `main`, unrelated to this PR).
  - `python -m compileall openjiuwen_deepsearch server` -> clean.
* Performance — No impact (adds only a type check per subsection result).

**Self-checklist**:

+ - [ ] **Design**: Has the solution corresponding to the PR been reviewed by the Maintainer, and have all review comments been replied to and revised
+ - [x] **Test**: Has the code in the PR been fully covered by UT/ST test cases, and have the newly added test cases been uploaded to the repository along with this PR or already uploaded.
+ - [x] **Verification**: Does the PR description contains a detailed description of the verification results regarding the achievement of the expected goals for the Feature, Refactor, and Bugfix to this PR.
+ - [x] **Interface**: Does it involve changes to external interfaces? (No external interface / public SDK / API changes.)
+ - [x] **Document**: Does it involve modifications to the official website documentation? (No — the documented chart-generation contract is unchanged; this is an internal robustness fix.)

<!-- **Special notes for your reviewers**: -->
<!-- + - [ ] Whether it causes forward compatibility failure -->
<!-- + - [ ] Whether the dependent third-party library change is involved -->
