### PR TITLE
fix(search): stop double-counting fail_count so DeepSearch terminates…

### DIFF
--- a/openjiuwen_deepsearch/framework/openjiuwen/agent/workflow.py
+++ b/openjiuwen_deepsearch/framework/openjiuwen/agent/workflow.py
@@ -1158,7 +1158,11 @@ class DeepSearchAgent(BaseAgent):
                     "total_input_tokens": self.total_input_tokens,
                     "total_output_tokens": self.total_output_tokens,
                     "log_dir": self.log_dir,
-                    "fail_count": self.fail_count,
+                    # Pass 0 so the sub-workflow reports a per-action delta (0/1),
+                    # not the running cumulative total. The parent accumulates it
+                    # at the completion site; passing self.fail_count here caused
+                    # the total to be double-counted (and inflated under parallelism).
+                    "fail_count": 0,
                 },
             )
 
@@ -1349,7 +1353,7 @@ class DeepSearchAgent(BaseAgent):
 
                 result: Result | None = state_result.get("result")
                 config = anonymize_config_for_logging(state_result.get("config", {}))
-                self.fail_count += config.get("fail_count", self.fail_count)
+                self.fail_count += config.get("fail_count", 0)
 
                 self.action_pool.record_completed(completed_action, result)
 

--- a/tests/search_agent/test_integration_search_loop.py
+++ b/tests/search_agent/test_integration_search_loop.py
@@ -242,6 +242,70 @@ async def test_answer_mode_top_k_returns_best_strength(
 
 
 @pytest.mark.asyncio
+async def test_fail_count_accumulates_one_per_failed_action(
+    monkeypatch: pytest.MonkeyPatch, tmp_log_dir: Path, base_action, base_state
+) -> None:
+    """Each failed action must raise the global fail_count by exactly 1.
+
+    Regression for the double-counting bug: the parent used to pass its
+    cumulative ``fail_count`` into every state_creation sub-workflow AND add the
+    (already-cumulative) returned value back with ``+=``. With ``fail_limit=3``
+    that tripped termination after 2 failed actions instead of 3. Here the mock
+    reproduces the real sub-workflow contract -- it returns the passed-in
+    ``fail_count`` incremented by 1 -- so the bug would surface as an early
+    termination.
+    """
+    agent = _make_agent(tmp_log_dir, fail_limit=3, max_workers=1)
+    actions = [
+        base_action.model_copy(
+            update={"id": f"action-{i}", "proposal": ActionProposal(direction=f"d{i}", score=0.5)}
+        )
+        for i in range(5)
+    ]
+    state_creation_calls: list[int] = []
+
+    async def _fake_run_workflow(*, workflow: str, inputs: dict) -> SimpleNamespace:
+        if workflow == "init_state_1":
+            return SimpleNamespace(
+                result={"init_state": base_state, "total_input_tokens": 0, "total_output_tokens": 0}
+            )
+        if workflow == "find_action_1":
+            return SimpleNamespace(
+                result={"actions": actions, "total_input_tokens": 0, "total_output_tokens": 0}
+            )
+        if workflow == "state_creation_1":
+            # Mirror algorithm/search_nodes/utils.py: the sub-workflow increments
+            # the fail_count it was handed and echoes it back inside ``config``.
+            passed_in = inputs.get("fail_count", 0)
+            state_creation_calls.append(passed_in)
+            return SimpleNamespace(
+                result={
+                    "result": None,
+                    "config": {"fail_count": passed_in + 1},
+                    "total_input_tokens": 0,
+                    "total_output_tokens": 0,
+                }
+            )
+        raise AssertionError(workflow)
+
+    monkeypatch.setattr(
+        "openjiuwen_deepsearch.framework.openjiuwen.agent.workflow.Runner.run_workflow",
+        _fake_run_workflow,
+    )
+
+    final = await agent._run_internal()
+
+    assert final.termination == "fail_limit"
+    # Exactly 3 failed actions are needed to reach fail_limit=3 (one increment
+    # each). The double-counting bug would terminate after only 2.
+    assert len(state_creation_calls) == 3
+    assert agent.fail_count == 3
+    # The parent must hand a per-action delta base of 0 to each sub-workflow,
+    # not its running cumulative total.
+    assert state_creation_calls == [0, 0, 0]
+
+
+@pytest.mark.asyncio
 async def test_answer_writes_final_result_json(
     monkeypatch: pytest.MonkeyPatch, tmp_log_dir: Path, base_action, base_state
 ) -> None:


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1) If this is your first time, please read our contributor guidelines: https://gitcode.com/openJiuwen/openJiuwen/blob/master/CONTRIBUTING.md

2) If you want to contribute your code but don't know who will review and merge, please add label `openJiuwen-assistant` to the pull request, we will find and do it as soon as possible.
-->

**What type of PR is this?**
<!-- 
Choose one label from `bug`, `task`, `feature` and `refactor`, and replace `<label>` below the comment block. 

If this pr is not only bugfix/task/feature and also a refactor, you can append `/kind refactor` label after `/kind bug`, `/kind task` and `/kind feature`.
-->
/kind bug

**What does this PR do / why do we need it**:

* Fix a double-counting bug in the DeepSearch action loop that made the agent terminate far too early.
* Each `state_creation` sub-workflow was invoked with the parent's cumulative `fail_count` (`workflow.py`), and the sub-workflow increments it by 1 on a failed action (`algorithm/search_nodes/utils.py`). The parent then added that already-cumulative value back with `+=`, re-adding the base every iteration and compounding under parallel workers. As a result `self.fail_count >= fail_limit` tripped much earlier than intended, and the agent returned `FAIL_LIMIT` with a missing or low-quality answer.
* Fix by making the accounting a per-action delta:
  - pass `fail_count=0` into each sub-workflow, so it reports only its own 0/1 increment rather than echoing back the running total;
  - accumulate that delta with a default of `0` (the previous default of `self.fail_count` doubled the counter whenever the key was absent).
* The intended contract is unchanged — `fail_limit` still means "terminate after N failed actions"; this PR makes the counter actually honor it.

**Which issue(s) this PR fixes**:

N/A (no tracked issue)

**What scenarios were tested, and what were the verification results (Function, performance, reliability, etc.)**:

* Function / Reliability — New integration regression test `test_fail_count_accumulates_one_per_failed_action` in `tests/search_agent/test_integration_search_loop.py`. It mirrors the real sub-workflow contract (returns the passed-in `fail_count + 1` inside `config`) and asserts that with `fail_limit=3` the loop needs exactly 3 failed actions to terminate, that `agent.fail_count == 3`, and that each sub-workflow is handed a delta base of `0`.
* Bug reproduction confirmed — With the fix temporarily reverted, the new test fails: termination fires after only 2 failed actions (`config` shows `fail_count` jumping 1 -> 2 -> limit). With the fix in place it passes.
* Regression / no side effects:
  - `pytest tests/search_agent/test_integration_search_loop.py` -> 5 passed.
  - Full `tests/search_agent` run -> passing (1 pre-existing failure `test_simple_react_telemetry_uses_built_tool_map`, confirmed failing on clean `main`, unrelated to this PR).
  - `python -m compileall openjiuwen_deepsearch server` -> clean.
* Performance — No impact.

**Self-checklist**:

+ - [ ] **Design**: Has the solution corresponding to the PR been reviewed by the Maintainer, and have all review comments been replied to and revised
+ - [x] **Test**: Has the code in the PR been fully covered by UT/ST test cases, and have the newly added test cases been uploaded to the repository along with this PR or already uploaded.
+ - [x] **Verification**: Does the PR description contains a detailed description of the verification results regarding the achievement of the expected goals for the Feature, Refactor, and Bugfix to this PR.
+ - [x] **Interface**: Does it involve changes to external interfaces? (No external interface / public SDK / API changes; only internal loop accounting.)
+ - [x] **Document**: Does it involve modifications to the official website documentation? (No — `fail_limit` semantics are unchanged; this restores the intended behavior.)

<!-- **Special notes for your reviewers**: -->
<!-- + - [ ] Whether it causes forward compatibility failure -->
<!-- + - [ ] Whether the dependent third-party library change is involved -->
