### PR TITLE
docs: prefer docker compose v2 version checks

### DIFF
--- a/deepsearch/docs/en/2.Installation Guide/DeepSearch Full Edition/Linux Installation.md
+++ b/deepsearch/docs/en/2.Installation Guide/DeepSearch Full Edition/Linux Installation.md
@@ -30,7 +30,7 @@ Ensure the machine meets:
 
     ```
     docker version
-    docker-compose version
+    docker compose version
     ```
 
 ## 2. Install DeepSearch (example: Ubuntu 22.04)

--- a/deepsearch/docs/en/2.Installation Guide/DeepSearch_SDK/Docker Installation/Linux Installation.md
+++ b/deepsearch/docs/en/2.Installation Guide/DeepSearch_SDK/Docker Installation/Linux Installation.md
@@ -24,7 +24,7 @@ Ensure the machine meets:
 
     ```
     docker version
-    docker-compose version
+    docker compose version
     ```
 
 ### Install MySQL (optional)

--- a/deepsearch/docs/zh/2.安装指导/DeepSearch_SDK/Docker方式安装/Linux系统安装.md
+++ b/deepsearch/docs/zh/2.安装指导/DeepSearch_SDK/Docker方式安装/Linux系统安装.md
@@ -24,7 +24,7 @@
 
     ```
     docker version
-    docker-compose version
+    docker compose version
     ```
 
 ### 安装 MySQL（可选组件）

--- a/deepsearch/docs/zh/2.安装指导/DeepSearch完整版/Linux系统安装.md
+++ b/deepsearch/docs/zh/2.安装指导/DeepSearch完整版/Linux系统安装.md
@@ -30,7 +30,7 @@
 
     ```
     docker version
-    docker-compose version
+    docker compose version
     ```
 
 ## 二、DeepSearch 安装（以下以 Ubuntu 22.04 为例）


### PR DESCRIPTION
﻿## Summary
- Install docs checked legacy `docker-compose version` (Compose v1).
- DeepSearch deployment needs Compose v2: `docker compose version`.

Fixes #177

## Test plan
- [ ] Spot-check updated Linux install guides (Full Edition + SDK Docker)
